### PR TITLE
Declare miner to depend on bitcoind

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,8 @@ services:
       --bitcoin-rpcpassword=btcpass
       --bitcoin-rpcuser=btcuser
       --block-interval-secs=600
+    depends_on:
+      - bitcoind
     image: miner
     networks:
       - miner


### PR DESCRIPTION
Otherwise it risks to start too early
```sh
$ dc logs miner
miner-1  | Starting miner server
miner-1  | thread 'tokio-runtime-worker' panicked at src/main.rs:69:78: miner-1  | called `Result::unwrap()` on an `Err` value: JsonRpc(Transport(SocketError(Custom { kind: Uncategorized, error: "failed to lookup address information: Name or service not known" }))) miner-1  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace miner-1  | miner exited
```