### PR TITLE
Do not restart always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
       # - greenlight-internal
       - lsp-internal
       - miner
-    restart: always
     volumes:
       - bitcoin:/data/.bitcoin
     ports:
@@ -100,7 +99,6 @@ services:
     image: postgres:16
     networks:
       - breez-internal
-    restart: always
     volumes:
       - server-postgres:/var/lib/postgresql/data
 
@@ -108,7 +106,6 @@ services:
     image: redis:7.2.4
     networks:
       - breez-internal
-    restart: always
 
   # greenlight-node1:
   #   command:
@@ -218,7 +215,6 @@ services:
     image: postgres:16
     networks:
       - lsp-internal
-    restart: always
     volumes:
       - lspd-postgres:/var/lib/postgresql/data
   


### PR DESCRIPTION
Otherwise docker starts the containers after reboot:
```
$ docker ps
CONTAINER ID   IMAGE         COMMAND                  CREATED       STATUS          PORTS                                                                                                                   NAMES
618875c1d40b   postgres:16   "docker-entrypoint.s…"   6 hours ago   Up 37 seconds   5432/tcp                                                                                                                breez-sdk-regtest-lspd-postgres-1
9166feaae31c   postgres:16   "docker-entrypoint.s…"   6 hours ago   Up 36 seconds   5432/tcp                                                                                                                breez-sdk-regtest-breez-server-postgres-1
3629de1964fd   bitcoind      "bitcoind -addressty…"   6 hours ago   Up 36 seconds   8080/tcp, 8332-8333/tcp, 18332-18333/tcp, 18444/tcp, 28332-28333/tcp, 0.0.0.0:18443->18443/tcp, [::]:18443->18443/tcp   breez-sdk-regtest-bitcoind-1
d65568e6a4f2   redis:7.2.4   "docker-entrypoint.s…"   6 hours ago   Up 37 seconds   6379/tcp                                                                                                                breez-sdk-regtest-breez-server-redis-1
```