### PR TITLE
Add Boltz swapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "boltz"]
+	path = boltz
+	url = https://github.com/BoltzExchange/regtest.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,18 @@
-
 services:
   alice-lightningd:
     command:
-      --bitcoin-rpcconnect=bitcoind
-      --bitcoin-rpcpassword=btcpass
-      --bitcoin-rpcport=18443
-      --bitcoin-rpcuser=btcuser
-      --database-upgrade=true
-      --grpc-host=0.0.0.0
-      --grpc-port=8888
-      --lightning-dir=/data/.lightning
-      --log-level=debug
-      --network=regtest
+      - --bitcoin-rpcconnect=bitcoind-breez
+      - --bitcoin-rpcpassword=btcpass
+      - --bitcoin-rpcport=18443
+      - --bitcoin-rpcuser=btcuser
+      - --database-upgrade=true
+      - --grpc-host=0.0.0.0
+      - --grpc-port=8888
+      - --lightning-dir=/data/.lightning
+      - --log-level=debug
+      - --network=regtest
     depends_on:
-      - bitcoind
+      - bitcoind-breez
       - lsp-lightningd
       - miner
     image: lightningd-alice
@@ -25,40 +24,40 @@ services:
       - alice-lightningd:/data/.lightning
       - lsp-lightningd:/data/.lightning-lsp
 
-  bitcoind:
+  bitcoind-breez:
     command:
-      -addresstype=bech32
-      -debug=mempool
-      -debug=rpc
-      -fallbackfee=0.00000253
-      -logtimestamps
-      -nolisten
-      -regtest
-      -rpcallowip=0.0.0.0/0
-      -rpcbind=0.0.0.0
-      -rpcpassword=btcpass
-      -rpcuser=btcuser
-      -rest
-      -server
-      -txindex
+      - -addresstype=bech32
+      - -debug=mempool
+      - -debug=rpc
+      - -fallbackfee=0.00000253
+      - -logtimestamps
+      - -nolisten
+      - -regtest
+      - -rpcallowip=0.0.0.0/0
+      - -rpcbind=0.0.0.0
+      - -rpcpassword=btcpass
+      - -rpcuser=btcuser
+      - -rest
+      - -server
+      - -txindex
+      - -addnode=boltz-bitcoind:18444
     image: bitcoind
     networks:
       - breez-internal
       # - greenlight-internal
       - lsp-internal
       - miner
+      - boltz
     restart: always
     volumes:
       - bitcoin:/data/.bitcoin
-    ports:
-      - 18443:18443
 
   breez-server:
     depends_on:
       - breez-server-postgres
       - breez-server-redis
     environment:
-      - BITCOIND_HOST=bitcoind
+      - BITCOIND_HOST=bitcoind-breez
       - BITCOIND_PASSWORD=btcpass
       - BITCOIND_PORT=18443
       - BITCOIND_USER=btcuser
@@ -112,7 +111,7 @@ services:
 
   # greenlight-node1:
   #   command:
-  #     --bitcoin-rpcconnect=bitcoind:18443
+  #     --bitcoin-rpcconnect=bitcoind-breez:18443
   #     --bitcoin-rpcpassword=btcpass
   #     --bitcoin-rpcuser=btcuser
   #     --disable-plugin=cln-grpc
@@ -124,7 +123,7 @@ services:
   #     --network=regtest
   #     --subdaemon=hsmd:/usr/local/bin/gl-signerproxy
   #   depends_on:
-  #     - bitcoind
+  #     - bitcoind-breez
   #     - greenlight-node1-scheduler
   #   environment:
   #     - CLN_PLUGIN_LOG=gl_plugin=trace,gl_signerproxy=trace,cln_client=trace,cln_grpc=trace,cln_rpc=trace,info
@@ -156,24 +155,24 @@ services:
 
   lsp-lightningd:
     command:
-      --bitcoin-rpcconnect=bitcoind
-      --bitcoin-rpcpassword=btcpass
-      --bitcoin-rpcport=18443
-      --bitcoin-rpcuser=btcuser
-      --database-upgrade=true
-      --dev-allowdustreserve=true
-      --dev-force-privkey=7d1886ac8c00ef7eb53ddc645dab2fe8a48f09940f8a49305aed3253bc49117f
-      --developer
-      --grpc-host=0.0.0.0
-      --grpc-port=8888
-      --lightning-dir=/data/.lightning
-      --log-level=debug
-      --lsp-listen=0.0.0.0:12312
-      --max-concurrent-htlcs=30
-      --network=regtest
-      --plugin=/usr/local/bin/lspd_cln_plugin
+      - --bitcoin-rpcconnect=bitcoind-breez
+      - --bitcoin-rpcpassword=btcpass
+      - --bitcoin-rpcport=18443
+      - --bitcoin-rpcuser=btcuser
+      - --database-upgrade=true
+      - --dev-allowdustreserve=true
+      - --dev-force-privkey=7d1886ac8c00ef7eb53ddc645dab2fe8a48f09940f8a49305aed3253bc49117f
+      - --developer
+      - --grpc-host=0.0.0.0
+      - --grpc-port=8888
+      - --lightning-dir=/data/.lightning
+      - --log-level=debug
+      - --lsp-listen=0.0.0.0:12312
+      - --max-concurrent-htlcs=30
+      - --network=regtest
+      - --plugin=/usr/local/bin/lspd_cln_plugin
     depends_on:
-      - bitcoind
+      - bitcoind-breez
       - miner
     image: lightningd-lsp
     networks:
@@ -183,6 +182,7 @@ services:
           - cln
       public-lightning:
       miner:
+      boltz:
     ports:
       - 19846:19846
     volumes:
@@ -221,16 +221,16 @@ services:
     restart: always
     volumes:
       - lspd-postgres:/var/lib/postgresql/data
-  
+
   miner:
     command:
-      --address=0.0.0.0:8888
-      --bitcoin-rpcconnect=bitcoind:18443
-      --bitcoin-rpcpassword=btcpass
-      --bitcoin-rpcuser=btcuser
-      --block-interval-secs=600
+      - --address=0.0.0.0:8888
+      - --bitcoin-rpcconnect=bitcoind-breez:18443
+      - --bitcoin-rpcpassword=btcpass
+      - --bitcoin-rpcuser=btcuser
+      - --block-interval-secs=600
     depends_on:
-      - bitcoind
+      - bitcoind-breez
     image: miner
     networks:
       - miner
@@ -250,13 +250,13 @@ services:
     volumes:
       - rgs-data:/usr/src/app/res
     links:
-      - bitcoind
+      - bitcoind-breez
       - rgs-postgres
     depends_on:
       - lsp-lightningd
       - rgs-postgres
     environment:
-      - BITCOIN_REST_DOMAIN=bitcoind
+      - BITCOIN_REST_DOMAIN=bitcoind-breez
       - BITCOIN_REST_PATH=/rest/
       - BITCOIN_REST_PORT=18443
       - LN_PEERS=0361984fe2a03cc594e97de423bf461096dd26a52e77feda68510377f360e430d4@lsp-lightningd:19846
@@ -265,7 +265,7 @@ services:
       - RAPID_GOSSIP_SYNC_SERVER_DB_PASSWORD=docker
       - RAPID_GOSSIP_SYNC_SERVER_DB_USER=lightning-rgs
       - RAPID_GOSSIP_SYNC_SERVER_NETWORK=regtest
-    command: ['sh', '-c', 'echo Give some time for LSP to start ... && sleep 5 && rapid-gossip-sync-server']
+    command: [ 'sh', '-c', 'echo Give some time for LSP to start ... && sleep 5 && rapid-gossip-sync-server' ]
     networks:
       - miner
       - public-lightning
@@ -282,26 +282,26 @@ services:
     networks:
       - rgs-internal
     ports:
-      - 5432:5432
+      - 5431:5432
 
   swapd:
     image: swapd
     command:
-      --address=0.0.0.0:58049
-      --auto-migrate
-      --network=regtest
-      --cln-grpc-address=http://alice-lightningd:8888
-      --cln-grpc-ca-cert=/data/.lightning/regtest/ca.pem
-      --cln-grpc-client-cert=/data/.lightning/regtest/client.pem
-      --cln-grpc-client-key=/data/.lightning/regtest/client-key.pem
-      --log-level=swapd=debug,info
-      --db-url=postgresql://swapd-user:swapd-pass@swapd-postgres/swapd-db?sslmode=disable
-      --bitcoind-rpc-address=http://bitcoind:18443
-      --bitcoind-rpc-user=btcuser
-      --bitcoind-rpc-password=btcpass
-      --chain-poll-interval-seconds=5
+      - --address=0.0.0.0:58049
+      - --auto-migrate
+      - --network=regtest
+      - --cln-grpc-address=http://alice-lightningd:8888
+      - --cln-grpc-ca-cert=/data/.lightning/regtest/ca.pem
+      - --cln-grpc-client-cert=/data/.lightning/regtest/client.pem
+      - --cln-grpc-client-key=/data/.lightning/regtest/client-key.pem
+      - --log-level=swapd=debug,info
+      - --db-url=postgresql://swapd-user:swapd-pass@swapd-postgres/swapd-db?sslmode=disable
+      - --bitcoind-rpc-address=http://bitcoind-breez:18443
+      - --bitcoind-rpc-user=btcuser
+      - --bitcoind-rpc-password=btcpass
+      - --chain-poll-interval-seconds=5
     depends_on:
-      - bitcoind
+      - bitcoind-breez
       - swapd-postgres
     networks:
       - breez-internal
@@ -327,7 +327,7 @@ services:
       - --daemon-dir
       - /config
       - --daemon-rpc-addr
-      - bitcoind:18443
+      - bitcoind-breez:18443
       - --cookie
       - btcuser:btcpass
       - --http-addr
@@ -336,7 +336,7 @@ services:
       - "*"
       - --jsonrpc-import
     depends_on:
-      - bitcoind
+      - bitcoind-breez
     entrypoint:
       - /build/electrs
     image: ghcr.io/vulpemventures/electrs:latest
@@ -354,6 +354,9 @@ networks:
   public-internet:
   public-lightning:
   rgs-internal:
+  boltz:
+    name: boltz_default
+    external: true
 
 volumes:
   # greenlight-node1-scheduler:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -xe
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$SCRIPT_DIR/boltz"
+./start.sh
+
+cd "$SCRIPT_DIR"
+docker compose down
+docker compose up --remove-orphans -d
+
+set +x
+
+source "$SCRIPT_DIR/boltz/aliases.sh"
+shopt -s expand_aliases
+
+CHECK_INTERVAL=2  
+TIMEOUT_SECONDS=120 
+FUNDING_UTXO_AMOUNT_BTC="0.6"
+FUNDING_UTXO_AMOUNT_MSAT=60000000000 # 0.6 BTC
+CHANNEL_AMOUNT_SATS=50000000 # 0.5 BTC
+
+LSP_CONTAINER_NAME="breez-sdk-regtest-lsp-lightningd-1"
+
+wait_for_condition() {
+    local condition_cmd="$1"
+    local description="$2"
+    local start_time=$(date +%s)
+
+    echo "Waiting for: $description"
+    while true; do
+        if eval "$condition_cmd"; then
+            echo "Condition met: $description"
+            return 0
+        fi
+
+        local current_time=$(date +%s)
+        local elapsed_time=$((current_time - start_time))
+
+        if [ $elapsed_time -ge $TIMEOUT_SECONDS ]; then
+            echo "Timeout waiting for: $description"
+            exit 1
+        fi
+
+        sleep $CHECK_INTERVAL
+    done
+}
+
+sleep 5
+
+wait_for_condition \
+    "! docker exec $LSP_CONTAINER_NAME cln getinfo | jq -e 'has(\"warning_bitcoind_sync\") or has(\"warning_lightningd_sync\")' > /dev/null" \
+    "LSP node ($LSP_CONTAINER_NAME) to sync to chain"
+
+
+echo "[+] Funding $LSP_CONTAINER_NAME with 2 UTXOs..."
+
+LSP_ADDRESS=$(docker exec $LSP_CONTAINER_NAME cln newaddr | jq -r .bech32)
+if [ -z "$LSP_ADDRESS" ]; then
+    echo "Error: Failed to get new address from $LSP_CONTAINER_NAME"
+    exit 1
+fi
+echo "  LSP Address: $LSP_ADDRESS"
+
+echo "  Sending $FUNDING_UTXO_AMOUNT_BTC BTC via alias to LSP (UTXO 1)..."
+TXID1=$(bitcoin-cli-sim-client sendtoaddress "$LSP_ADDRESS" $FUNDING_UTXO_AMOUNT_BTC)
+echo "    Funding TXID 1: $TXID1"
+echo "  Sending $FUNDING_UTXO_AMOUNT_BTC BTC via alias to LSP (UTXO 2)..."
+TXID2=$(bitcoin-cli-sim-client sendtoaddress "$LSP_ADDRESS" $FUNDING_UTXO_AMOUNT_BTC)
+echo "    Funding TXID 2: $TXID2"
+
+echo "  Mining 10 blocks via alias for confirmation..."
+bitcoin-cli-sim-client -generate 10
+
+# Wait for LSP to see the two specific confirmed funds
+wait_for_condition \
+    "count=\$(docker exec $LSP_CONTAINER_NAME cln listfunds | jq --argjson amount $FUNDING_UTXO_AMOUNT_MSAT '[.outputs[] | select(.status == \"confirmed\" and .amount_msat == \$amount)] | length'); [ \"\$count\" -ge 2 ]" \
+    "LSP node ($LSP_CONTAINER_NAME) to detect 2 confirmed funding UTXOs of $FUNDING_UTXO_AMOUNT_MSAT msat each"
+
+echo "  LSP On-chain Balance ($LSP_CONTAINER_NAME):"
+docker exec $LSP_CONTAINER_NAME cln listfunds
+
+echo "[+] Opening channels from $LSP_CONTAINER_NAME to Boltz nodes..."
+
+# Get Boltz node details
+echo "  Fetching Boltz node details..."
+LND2_INFO_JSON=$(lncli-sim 2 getinfo)
+LND2_PUBKEY=$(echo $LND2_INFO_JSON | jq -r '.identity_pubkey')
+LND2_HOST="boltz-lnd-2" 
+LND2_PORT="9735" 
+LND2_URI="${LND2_PUBKEY}@${LND2_HOST}:${LND2_PORT}"
+echo "    LND2 URI: $LND2_URI"
+
+CLN2_INFO_JSON=$(lightning-cli-sim 2 getinfo)
+CLN2_PUBKEY=$(echo $CLN2_INFO_JSON | jq -r '.id')
+CLN2_HOST="boltz-cln-2" 
+CLN2_PORT="9735" 
+CLN2_URI="${CLN2_PUBKEY}@${CLN2_HOST}:${CLN2_PORT}"
+echo "    CLN2 URI: $CLN2_URI"
+
+if [ -z "$LND2_PUBKEY" ] || [ -z "$CLN2_PUBKEY" ]; then
+    echo "Error: Failed to get pubkey for one or both Boltz nodes."
+    exit 1
+fi
+
+# Connect lsp-lightningd to Boltz nodes (if not already connected)
+echo "  Attempting to connect $LSP_CONTAINER_NAME to Boltz nodes..."
+if ! docker exec $LSP_CONTAINER_NAME cln listpeers | jq -e --arg PK "$LND2_PUBKEY" '.peers[] | select(.id == $PK and .connected == true)' > /dev/null; then
+    docker exec $LSP_CONTAINER_NAME cln connect "$LND2_PUBKEY" "$LND2_HOST" "$LND2_PORT" || echo "    Warn: Error connecting to LND2 ($LND2_URI)"
+else
+    echo "    Already connected to LND2."
+fi
+if ! docker exec $LSP_CONTAINER_NAME cln listpeers | jq -e --arg PK "$CLN2_PUBKEY" '.peers[] | select(.id == $PK and .connected == true)' > /dev/null; then
+    docker exec $LSP_CONTAINER_NAME cln connect "$CLN2_PUBKEY" "$CLN2_HOST" "$CLN2_PORT" || echo "    Warn: Error connecting to CLN2 ($CLN2_URI)"
+else
+    echo "    Already connected to CLN2."
+fi
+
+# Wait for connections to establish
+wait_for_condition "docker exec $LSP_CONTAINER_NAME cln listpeers | jq -e --arg PK '$LND2_PUBKEY' '.peers[] | select(.id == \$PK and .connected == true)' > /dev/null" "LSP ($LSP_CONTAINER_NAME) to connect to LND2 ($LND2_PUBKEY)"
+wait_for_condition "docker exec $LSP_CONTAINER_NAME cln listpeers | jq -e --arg PK '$CLN2_PUBKEY' '.peers[] | select(.id == \$PK and .connected == true)' > /dev/null" "LSP ($LSP_CONTAINER_NAME) to connect to CLN2 ($CLN2_PUBKEY)"
+
+# Open channels (0.5 BTC each)
+echo "  Opening channel to LND2 ($LND2_URI) for $CHANNEL_AMOUNT_SATS sats..."
+docker exec $LSP_CONTAINER_NAME cln fundchannel "$LND2_PUBKEY" $CHANNEL_AMOUNT_SATS
+
+echo "  Opening channel to CLN2 ($CLN2_URI) for $CHANNEL_AMOUNT_SATS sats..."
+docker exec $LSP_CONTAINER_NAME cln fundchannel "$CLN2_PUBKEY" $CHANNEL_AMOUNT_SATS
+
+sleep 5
+
+# confirm channels
+echo "  Mining 12 blocks via alias for channel confirmation..."
+bitcoin-cli-sim-client -generate 6
+
+# Wait for channels to become active
+wait_for_condition \
+    "docker exec $LSP_CONTAINER_NAME cln listpeerchannels $LND2_PUBKEY | jq -e '.channels[]? | select(.state == \"CHANNELD_NORMAL\")' > /dev/null" \
+    "Channel with LND2 ($LND2_PUBKEY) to become active (CHANNELD_NORMAL)"
+wait_for_condition \
+    "docker exec \"$LSP_CONTAINER_NAME\" cln listpeerchannels \"$CLN2_PUBKEY\" | jq -e '.channels[]? | select(.state == \"CHANNELD_NORMAL\")' > /dev/null" \
+    "Channel with LND2 ($LND2_PUBKEY) to become active (CHANNELD_NORMAL)"
+
+echo "  LSP Channel List ($LSP_CONTAINER_NAME):"
+docker exec $LSP_CONTAINER_NAME cln listchannels
+
+echo "[+] Setup complete."

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -xe
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$SCRIPT_DIR"
+docker compose down --volumes
+
+cd "$SCRIPT_DIR/boltz"
+./stop.sh


### PR DESCRIPTION
This adds boltz to the regtest environment. I propose to use https://github.com/BoltzExchange/regtest as a submodule so that we can easily be up-to-date with the latest Boltz backend.

Changelist:

- Added submodule
- Renamed the existing bitcoind service to bitcoind-breez to avoid conflicts with the bitcoind already in the boltz compose. We could rely on the boltz bitcoind instance only but it would require using cookie auth and I didn't pursue that for now to minimize changes.
- Connected both bitcoind instances
- Added start and stop scripts. The start one sets up channels from the LSP to both boltz lightning nodes